### PR TITLE
fix telegraf version mismatch in the manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -15,7 +15,7 @@ exclude_files:
 url_to_dependency_map:
 - match: telegraf.tgz
   name: telegraf
-  version: 1.14.3
+  version: 1.25.2
 - match: cf.tgz
   name: cf
   version: 6.51.0


### PR DESCRIPTION
upgrade telegraf from 1.14.3 to 1.25.2 version. 