### PR TITLE
Improve syntax for safety and readability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[{*.sh,bin/**}]
+indent_style = space
+indent_size = 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["Buildpack", "cflinuxfs"]
+}

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -6,4 +6,4 @@ Contributor License Agreement (CLA).
 
 If you haven’t previously signed a Comcast CLA, we can e-mail you a PDF that
 you can sign and scan back to us.   Please send us an e-mail or create a new
-GiHhub issue to request a PDF version of the CLA.
+GiHub issue to request a PDF version of the CLA.

--- a/README.md
+++ b/README.md
@@ -3,31 +3,31 @@
 A Cloud Foundry [buildpack](http://docs.cloudfoundry.org/buildpacks/) to run
 InfluxData Telegraf as an application in Cloud Foundry.
 
-### Building the Buildpack
+## Building the Buildpack
 
 1. Make sure you have fetched submodules
 
-    ```sh
-    git submodule update --init
-    ```
+   ```sh
+   git submodule update --init
+   ```
 
 1. Get latest buildpack dependencies
 
-    ```sh
-    BUNDLE_GEMFILE=cf.Gemfile bundle
-    ```
+   ```sh
+   BUNDLE_GEMFILE=cf.Gemfile bundle
+   ```
 
 1. Build the buildpack
 
-    ```sh
-    BUNDLE_GEMFILE=cf.Gemfile bundle exec buildpack-packager [ --cached | --uncached ] [--stack=STACK | --any-stack]
-    ```
+   ```sh
+   BUNDLE_GEMFILE=cf.Gemfile bundle exec buildpack-packager [ --cached | --uncached ] [--stack=STACK | --any-stack]
+   ```
 
-### Use in Cloud Foundry
+## Use in Cloud Foundry
 
-  Upload the buildpack to your Cloud Foundry and optionally specify it by name
+Upload the buildpack to your Cloud Foundry and optionally specify it by name
 
-  ```sh
-  cf create-buildpack telegraf_buildpack telegraf_buildpack.zip 1
-  cf push my_app -b telegraf_buildpack
-  ```
+```sh
+cf create-buildpack telegraf_buildpack telegraf_buildpack.zip 1
+cf push my_app -b telegraf_buildpack
+```

--- a/bin/compile
+++ b/bin/compile
@@ -16,24 +16,28 @@
 
 # bin/compile <build-dir> <cache-dir>
 
-set -e            # fail fast
-set -o pipefail   # do not ignore exit codes when piping output
-set -u            # treat  unset variables as an error
-# set -x          # enable debugging
+set -e          # fail fast
+set -o pipefail # do not ignore exit codes when piping output
+set -u          # treat  unset variables as an error
+# set -x        # enable debugging
 
 # Configure directories
 build_dir=$1
-cache_dir=$2
+# cache_dir=$2 # no caching
 
-compile_buildpack_dir=$(cd $(dirname $0); cd ..; pwd)
+compile_buildpack_dir=$(
+  cd "$(dirname "$0")"
+  cd ..
+  pwd
+)
 compile_buildpack_bin=$compile_buildpack_dir/bin
 
-cd $build_dir
+cd "$build_dir"
 mkdir -p bin
 
 for f in telegraf.tgz cf.tgz jq; do
   translated_url="$(
-    $compile_buildpack_dir/compile-extensions/bin/download_dependency $f /tmp
+    "$compile_buildpack_dir"/compile-extensions/bin/download_dependency "$f" /tmp
   )"
   echo "Downloaded [$translated_url]"
 done
@@ -42,6 +46,6 @@ tar xfz /tmp/telegraf.tgz --strip-components 4 --wildcards -C bin './*/usr/bin/t
 tar xfz /tmp/cf.tgz -C bin
 chmod 755 /tmp/jq && mv /tmp/jq bin
 
-cp -pr $compile_buildpack_dir/conf .
-cp $compile_buildpack_bin/config-*.sh bin/
-cp $compile_buildpack_bin/entrypoint.sh .
+cp -pr "$compile_buildpack_dir"/conf .
+cp "$compile_buildpack_bin"/config-*.sh bin/
+cp "$compile_buildpack_bin"/entrypoint.sh .

--- a/bin/config-global-tags.sh
+++ b/bin/config-global-tags.sh
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e            # fail fast
-set -o pipefail   # do not ignore exit codes when piping output
-set -u            # treat  unset variables as an error
+set -e          # fail fast
+set -o pipefail # do not ignore exit codes when piping output
+set -u          # treat  unset variables as an error
 # set -x          # enable debugging
 
 # Generate global_tags.conf file from VCAP_SERVICES
@@ -45,9 +45,9 @@ set -u            # treat  unset variables as an error
 #   state = "pa"
 
 TELEGRAF_CONFIG_DIRECTORY=${TELEGRAF_CONFIG_DIRECTORY:-conf}
-mkdir -p $TELEGRAF_CONFIG_DIRECTORY
+mkdir -p "$TELEGRAF_CONFIG_DIRECTORY"
 
-jq <<< $VCAP_SERVICES > $TELEGRAF_CONFIG_DIRECTORY/global_tags.conf -r '
+jq <<<"$VCAP_SERVICES" >"$TELEGRAF_CONFIG_DIRECTORY"/global_tags.conf -r '
   flatten[]
   |select(.name|startswith("tags"))
   |.credentials

--- a/bin/config-influxdb-output.sh
+++ b/bin/config-influxdb-output.sh
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e            # fail fast
-set -o pipefail   # do not ignore exit codes when piping output
-set -u            # treat  unset variables as an error
+set -e          # fail fast
+set -o pipefail # do not ignore exit codes when piping output
+set -u          # treat  unset variables as an error
 # set -x          # enable debugging
 
 # Generate influxdb.conf file from VCAP_SERVICES
@@ -47,9 +47,9 @@ set -u            # treat  unset variables as an error
 #   urls = ["http://localhost:8086"]
 
 TELEGRAF_CONFIG_DIRECTORY=${TELEGRAF_CONFIG_DIRECTORY:-conf}
-mkdir -p $TELEGRAF_CONFIG_DIRECTORY
+mkdir -p "$TELEGRAF_CONFIG_DIRECTORY"
 
-jq <<< $VCAP_SERVICES > $TELEGRAF_CONFIG_DIRECTORY/influxdb.conf -r '
+jq <<<"$VCAP_SERVICES" >"$TELEGRAF_CONFIG_DIRECTORY"/influxdb.conf -r '
   flatten[]
   |select(.name|startswith("influx"))
   |.credentials

--- a/bin/detect
+++ b/bin/detect
@@ -16,7 +16,7 @@
 
 # bin/detect <build-dir>
 
-if [ -f $1/telegraf.conf ]; then
+if [[ -f $1/telegraf.conf ]]; then
   echo telegraf && exit 0
 else
   exit 1

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PATH=$PWD/bin:$PATH
+PATH="$PWD/bin:$PATH"
 
 TELEGRAF_CONFIG_PATH=${TELEGRAF_CONFIG_PATH:-telegraf.conf}
 export TELEGRAF_CONFIG_PATH
@@ -24,4 +24,4 @@ TELEGRAF_CONFIG_DIRECTORY=${TELEGRAF_CONFIG_DIRECTORY:-conf}
 config-influxdb-output.sh
 config-global-tags.sh
 
-exec telegraf -config-directory $TELEGRAF_CONFIG_DIRECTORY
+exec telegraf -config-directory "$TELEGRAF_CONFIG_DIRECTORY"

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,43 +1,43 @@
 ---
 language: telegraf
 exclude_files:
-- ".git/"
-- ".gitignore"
-- ".gitmodules"
-- ".rspec"
-- "*Gemfile*"
-- cf_spec/
-- spec/
-- log/
-- test/
-- buildpack-packager/
-- telegraf_buildpack-*v*.zip
+  - .git/
+  - .gitignore
+  - .gitmodules
+  - .rspec
+  - "*Gemfile*"
+  - cf_spec/
+  - spec/
+  - log/
+  - test/
+  - buildpack-packager/
+  - telegraf_buildpack-*v*.zip
 url_to_dependency_map:
-- match: telegraf.tgz
-  name: telegraf
-  version: 1.25.2
-- match: cf.tgz
-  name: cf
-  version: 6.51.0
-- match: jq
-  name: jq
-  version: 1.6
+  - match: telegraf.tgz
+    name: telegraf
+    version: 1.25.2
+  - match: cf.tgz
+    name: cf
+    version: 6.51.0
+  - match: jq
+    name: jq
+    version: 1.6
 dependencies:
-- name: telegraf
-  version: 1.25.2
-  uri: https://dl.influxdata.com/telegraf/releases/telegraf-1.25.2_linux_amd64.tar.gz
-  sha256: 510bde1bdfcc8465a5864c7d8e5848fb21dcb4940175137ab665133f1edfecdc
-  cf_stacks:
-  - cflinuxfs3
-- name: cf
-  version: 6.51.0
-  uri: https://bit.ly/3i0RtcI
-  sha256: cf49127bf52c139e608d76424c77aa0123291897ac6d121a432bdad4ba7a4b58  
-  cf_stacks:
-  - cflinuxfs3
-- name: jq
-  version: 1.6
-  uri: https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
-  sha256: af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44
-  cf_stacks:
-  - cflinuxfs3
+  - name: telegraf
+    version: 1.25.2
+    uri: https://dl.influxdata.com/telegraf/releases/telegraf-1.25.2_linux_amd64.tar.gz
+    sha256: 510bde1bdfcc8465a5864c7d8e5848fb21dcb4940175137ab665133f1edfecdc
+    cf_stacks:
+      - cflinuxfs3
+  - name: cf
+    version: 6.51.0
+    uri: https://bit.ly/3i0RtcI
+    sha256: cf49127bf52c139e608d76424c77aa0123291897ac6d121a432bdad4ba7a4b58
+    cf_stacks:
+      - cflinuxfs3
+  - name: jq
+    version: 1.6
+    uri: https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+    sha256: af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44
+    cf_stacks:
+      - cflinuxfs3


### PR DESCRIPTION
## Why

1. All shell scripts deserve to be shellchedked to catch potential issues and, scripts safe and readable.
2. Standardize shell and yaml formatting.
3. Fix typos.