### PR TITLE
Bump dependencies and update build procedure

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 telegraf_buildpack*.zip
+vendor/

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ InfluxData Telegraf as an application in Cloud Foundry.
    git submodule update --init
    ```
 
-1. Get latest buildpack dependencies
+2. Get latest buildpack dependencies
 
    ```sh
-   BUNDLE_GEMFILE=cf.Gemfile bundle
+   BUNDLE_GEMFILE=cf.Gemfile bundle install
    ```
 
-1. Build the buildpack
+3. Build the buildpack
 
    ```sh
-   BUNDLE_GEMFILE=cf.Gemfile bundle exec buildpack-packager [ --cached | --uncached ] [--stack=STACK | --any-stack]
+   BUNDLE_GEMFILE=cf.Gemfile bundle exec buildpack-packager --cached --any-stack
    ```
 
 ## Use in Cloud Foundry

--- a/cf.Gemfile
+++ b/cf.Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-ruby '2.6.8'
+ruby '2.6.10'
 
 gem 'buildpack-packager', git: 'https://github.com/cloudfoundry/buildpack-packager', tag: 'v2.3.22'

--- a/cf.Gemfile.lock
+++ b/cf.Gemfile.lock
@@ -17,11 +17,11 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    concurrent-ruby (1.2.0)
+    concurrent-ruby (1.2.2)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     kwalify (0.7.2)
-    minitest (5.17.0)
+    minitest (5.20.0)
     semantic (1.6.1)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -37,7 +37,7 @@ DEPENDENCIES
   buildpack-packager!
 
 RUBY VERSION
-   ruby 2.6.8p205
+   ruby 2.6.10p210
 
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
## Why

- Bump dependencies to keep up-to-date with security patches
- Update build procedure to vendor dependencies locally